### PR TITLE
pip install django-freshdesk uninstalls Django 1.7.0+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=[
-        'Django>=1.5.0,<1.7',
+        'Django>=1.5.0,<1.8',
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Changed the install_requires to 'Django>=1.5.0,<1.8' to avoid an issue with pip uninstalling Django 1.7.1 in favour of Django 1.6.8 when I added django-freshdesk to my requirements.

It appears that tests are already passing for Django 1.7 in Travis but if there are any problems in the field I'll open up an issue/PR
