### PR TITLE
Add support for Django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
 python: 2.7
 env:
+  - TOX_ENV=py34-django18
   - TOX_ENV=py34-django17
   - TOX_ENV=py34-django16
+  - TOX_ENV=py33-django18
   - TOX_ENV=py33-django17
   - TOX_ENV=py33-django16
+  - TOX_ENV=py27-django18
   - TOX_ENV=py27-django17
   - TOX_ENV=py27-django16
   - TOX_ENV=py26-django16

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
-nose==1.3.4
-django-nose==1.2
+nose==1.3.6
+django-nose==1.4

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=[
-        'Django>1.5,<1.8',
+        'Django>1.5,<1.9',
     ],
     include_package_data=True,
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,13 @@ envlist =
     py26-django16,
     py27-django16,
     py27-django17,
+    py27-django18,
     py33-django16,
     py33-django17,
+    py33-django18,
     py34-django16,
     py34-django17,
+    py34-django18,
 
 [django16]
 deps =
@@ -17,6 +20,11 @@ deps =
 [django17]
 deps =
     Django>=1.7,<1.8
+    -r{toxinidir}/requirements-test.txt
+
+[django18]
+deps =
+    Django>=1.8,<1.9
     -r{toxinidir}/requirements-test.txt
 
 [testenv]
@@ -38,6 +46,10 @@ deps = {[django16]deps}
 basepython = python2.7
 deps = {[django17]deps}
 
+[testenv:py27-django18]
+basepython = python2.7
+deps = {[django18]deps}
+
 [testenv:py33-django16]
 basepython = python3.3
 deps = {[django16]deps}
@@ -46,6 +58,10 @@ deps = {[django16]deps}
 basepython = python3.3
 deps = {[django17]deps}
 
+[testenv:py33-django18]
+basepython = python3.3
+deps = {[django18]deps}
+
 [testenv:py34-django16]
 basepython = python3.4
 deps = {[django16]deps}
@@ -53,6 +69,10 @@ deps = {[django16]deps}
 [testenv:py34-django17]
 basepython = python3.4
 deps = {[django17]deps}
+
+[testenv:py34-django18]
+basepython = python3.4
+deps = {[django18]deps}
 
 [testenv:flake8]
 basepython=python
@@ -71,6 +91,6 @@ commands =
     coverage run --branch runtests.py
     coveralls
 deps =
-    {[django17]deps}
+    {[django18]deps}
     coverage==3.7.1
     coveralls==0.4.4


### PR DESCRIPTION
Add Tox environments for Django 1.8 using Python 2.7, 3.3, 3.4

Update nose and django-nose version requirements for compatibility with
Django 1.8.