### PR TITLE
Fresh desk will change Simple SSO url format effective April 28

### DIFF
--- a/freshdesk/views.py
+++ b/freshdesk/views.py
@@ -32,6 +32,6 @@ def authenticate(request):
         full_name, request.user.email, utctime)
     generated_hash = hmac.new(
         settings.FRESHDESK_SECRET_KEY.encode(), data.encode(), hashlib.md5).hexdigest()
-    url = '{0}login/sso?name={1}&email={2}&timestamp={3}&hash={4}'.format(settings.FRESHDESK_URL,
-        urlquote(full_name), urlquote(request.user.email), utctime, generated_hash)
+    url = '{0}login/sso?name={1}&hash={2}&email={3}&timestamp={4}'.format(settings.FRESHDESK_URL,
+        urlquote(full_name), generated_hash, urlquote(request.user.email), utctime)
     return HttpResponseRedirect(iri_to_uri(url))


### PR DESCRIPTION
Just received a message from Freshdesk advising that the Simple SSO url format is changing for security reasons to a form different than the one generated by django-freshdesk.

The pull request is pretty simple, I've just shuffled the elements into the order recommended by Freshdesk: Name, Shared secret key, Email address, and Timestamp

Support for the old format ends 28 April 2016 at 11 PM PDT so it seems like a pretty important change.