### PR TITLE
Change data for HMAC-MD5 per Freshdesk's change

### DIFF
--- a/freshdesk/views.py
+++ b/freshdesk/views.py
@@ -28,8 +28,8 @@ def authenticate(request):
     full_name = '{0} {1}'.format(first_name, last_name) if first_name or last_name else username
 
     utctime = int(time.time())
-    data = '{0}{1}{2}'.format(
-        full_name, request.user.email, utctime)
+    data = '{0}{1}{2}{3}'.format(
+        full_name, settings.FRESHDESK_SECRET_KEY, request.user.email, utctime)
     generated_hash = hmac.new(
         settings.FRESHDESK_SECRET_KEY.encode(), data.encode(), hashlib.md5).hexdigest()
     url = '{0}login/sso?name={1}&email={2}&timestamp={3}&hash={4}'.format(settings.FRESHDESK_URL,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
 nose==1.3.6
-django-nose==1.4
+django-nose==1.4.3


### PR DESCRIPTION
Freshdesk changed the data on which HMAC-MD5 must be computed. This data
now consists of name, secret key, email, and time stamp. The secret key is
the new addition.
https://support.freshdesk.com/support/solutions/articles/31166-single-sign-on-remote-authentication-in-freshdesk