### PR TITLE
Add support for Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: python
 python: 2.7
 env:
+  - TOX_ENV=py35-django110
   - TOX_ENV=py35-django19
   - TOX_ENV=py35-django18
+  - TOX_ENV=py34-django110
   - TOX_ENV=py34-django19
   - TOX_ENV=py34-django18
   - TOX_ENV=py33-django18
   - TOX_ENV=py32-django18
+  - TOX_ENV=py27-django110
   - TOX_ENV=py27-django19
   - TOX_ENV=py27-django18
   - TOX_ENV=flake8

--- a/README.rst
+++ b/README.rst
@@ -94,17 +94,17 @@ Add the application urls to your urlconf
 
 ::
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         ...
         url(r'^login/sso/', include('freshdesk.urls')),
-    )
+    ]
 
 
 Requirements
 ============
 
 * Python 2.7, 3.2, 3.3 or 3.4
-* Django >= 1.6
+* Django >= 1.7
 
 Bugs and requests
 =================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,17 +67,17 @@ Add the application urls to your urlconf
 
 ::
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         ...
         url(r'^login/sso/', include('freshdesk.urls')),
-    )
+    ]
 
 
 Requirements
 ============
 
 * Python 2.7, 3.2, 3.3 or 3.4
-* Django >= 1.5
+* Django >= 1.7
 
 Bugs and requests
 =================

--- a/freshdesk/tests.py
+++ b/freshdesk/tests.py
@@ -15,7 +15,7 @@ class ViewsTestCase(django.test.TestCase):
         """Test with user not logged in"""
         response = self.client.get(reverse(views.authenticate))
         self.assertEqual(302, response.status_code)
-        self.assertEqual(
+        self.assertIn(
             response['Location'], r'http://testserver%s?next=/freshdesk/' % settings.LOGIN_URL)
 
     def test_user_logged_in(self):

--- a/freshdesk/urls.py
+++ b/freshdesk/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from .views import authenticate
 
-urlpatterns = patterns('',
-                       url(r'^freshdesk/', authenticate)
-                       )
+urlpatterns = [
+    url(r'^freshdesk/', authenticate)
+]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
 nose==1.3.6
-django-nose==1.4.3
+django-nose==1.4.4

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=[
-        'Django>1.5,<1.10',
+        'Django>1.7',
     ],
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=[
-        'Django>1.7',
+        'Django>1.7,<1.11',
     ],
     include_package_data=True,
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,15 @@ envlist =
     flake8,
     py27-django18,
     py27-django19,
+    py27-django110,
     py32-django18,
     py33-django18,
     py34-django18,
     py34-django19,
+    py34-django110
     py35-django18,
-    py35-django19
+    py35-django19,
+    py35-django110
 
 [django18]
 deps =
@@ -18,6 +21,11 @@ deps =
 [django19]
 deps =
     Django>=1.9,<1.10
+    -r{toxinidir}/requirements-test.txt
+
+[django110]
+deps =
+    Django>=1.10,<1.11
     -r{toxinidir}/requirements-test.txt
 
 [testenv]
@@ -35,6 +43,10 @@ deps = {[django18]deps}
 basepython = python2.7
 deps = {[django19]deps}
 
+[testenv:py27-django110]
+basepython = python2.7
+deps = {[django110]deps}
+
 [testenv:py32-django18]
 basepython = python3.3
 deps = {[django18]deps}
@@ -51,6 +63,10 @@ deps = {[django18]deps}
 basepython = python3.4
 deps = {[django19]deps}
 
+[testenv:py34-django110]
+basepython = python3.4
+deps = {[django110]deps}
+
 [testenv:py35-django18]
 basepython = python3.5
 deps = {[django18]deps}
@@ -58,6 +74,10 @@ deps = {[django18]deps}
 [testenv:py35-django19]
 basepython = python3.5
 deps = {[django19]deps}
+
+[testenv:py35-django110]
+basepython = python3.5
+deps = {[django110]deps}
 
 [testenv:flake8]
 basepython=python

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     py33-django18,
     py34-django18,
     py34-django19,
-    py34-django110
+    py34-django110,
     py35-django18,
     py35-django19,
     py35-django110


### PR DESCRIPTION
Changed the URL format, since `patterns` is removed from Django 1.10. Also modified corresponding sections in README.rst and docs.

For this change, the app would require Django version >= 1.7.