### PR TITLE
Added support for django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,17 @@ python:
   - "3.5"
   - "3.6"
 env:
+  - TOX_ENV=py35-django111
   - TOX_ENV=py35-django110
   - TOX_ENV=py35-django19
   - TOX_ENV=py35-django18
+  - TOX_ENV=py34-django111
   - TOX_ENV=py34-django110
   - TOX_ENV=py34-django19
   - TOX_ENV=py34-django18
   - TOX_ENV=py33-django18
   - TOX_ENV=py32-django18
+  - TOX_ENV=py27-django111
   - TOX_ENV=py27-django110
   - TOX_ENV=py27-django19
   - TOX_ENV=py27-django18

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=[
-        'Django>1.7,<1.11',
+        'Django>1.7,<2.0',
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
The package claims being incompatible with django 1.11 because `install_requires` in setup.py was misconfigured.